### PR TITLE
Add pages

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,5 @@
+export default function About() {
+    return (
+        <div>foo</div>
+    )
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { Raleway, Geist_Mono } from "next/font/google";
-import { Hero } from "../components/Hero";
 import Header from "../components/Header";
 
 import "./globals.css";
@@ -53,8 +52,6 @@ export default function RootLayout({
         <ColorSchemeScript />
         <MantineProvider theme={theme} cssVariablesResolver={resolver}>
           <Header />
-          <Hero />
-          <div style={{ height: 50 }}></div>
           {children}
         </MantineProvider>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,8 @@
 import { Container } from "@mantine/core";
 import ProjectTile from "../components/ProjectTile";
 import { useState } from "react";
+import { Hero } from "../components/Hero";
+
 import classes from "../components/ProjectTile.module.css";
 
 const projectTiles = [
@@ -31,8 +33,12 @@ const projects = projectTiles.map((tile) => (
 
 export default function Home() {
   return (
-    <Container className={classes.wrapper} size="xl">
-      {projects}
-    </Container>
+    <div>
+      <Hero />
+      <div style={{ height: 50 }}></div>
+      <Container className={classes.wrapper} size="xl">
+        {projects}
+      </Container>
+    </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,7 +8,9 @@ import classes from "../components/ProjectTile.module.css";
 const projectTiles = [
   { link: '/rabbit', tileImg: "https://static.annejulian.net/static/img/rabbit/rabbit.png", tileText: "lorem ipsum dolor sit amet", key: 'rabbit' },
   { link: '/miniped', tileImg: "https://static.annejulian.net/static/img/miniped/mastminiped.jpg", tileText: "lorem ipsum dolor sit amet", key: 'miniped' },
-  { link: '/dive', tileImg: "https://static.annejulian.net/static/img/dive/mastdive.jpg", tileText: "lorem ipsum dolor sit amet", key: 'dive' }
+  { link: '/dive', tileImg: "https://static.annejulian.net/static/img/dive/mastdive.jpg", tileText: "lorem ipsum dolor sit amet", key: 'dive' },
+  { link: '/drone', tileImg: "https://static.annejulian.net/static/img/drone/drone_hero.png", tileText: "lorem ipsum dolor sit amet", key: 'drone' },
+  { link: '/gs750', tileImg: "https://static.annejulian.net/static/img/gs750/gs750_hero.png", tileText: "lorem ipsum dolor sit amet", key: 'gs750' }
 ]
 
 // const [active, setActive] = useState(projectTiles[0].link);

--- a/src/app/work/page.tsx
+++ b/src/app/work/page.tsx
@@ -1,0 +1,5 @@
+export default function Work() {
+    return (
+        <div>bar</div>
+    )
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react';
+import Link from 'next/link'
 import { Burger, Container, Drawer, Group, Stack } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { FaHome, FaGithub, FaLinkedin } from 'react-icons/fa';
@@ -18,19 +19,17 @@ export default function HeaderSimple() {
     const [active, setActive] = useState(links[0].link);
 
     const items = links.map((link) => (
-        <a
+        <Link
             key={link.key}
             href={link.link}
             className={classes.link}
             data-active={active === link.link || undefined}
-            onClick={(event) => {
-                event.preventDefault();
+            onClick={() => {
                 setActive(link.link);
-                toggle();
             }}
         >
             {link.label}
-        </a>
+        </Link>
     ));
 
     return (


### PR DESCRIPTION
This PR adds the rest of the project tiles and pages linked from the header:

- Created `About` and `Work` folders for NextJS routing
- Enabled onClick/navigation for the header navigation
- Added remaining projects to the project list 