### PR TITLE
Add project log components and content file

### DIFF
--- a/src/components/ProjectLog.tsx
+++ b/src/components/ProjectLog.tsx
@@ -1,0 +1,49 @@
+import { Group } from "@mantine/core"
+import classes from "./ProjectLogItem.module.css"
+
+interface LogItemProps {
+    leadElement: "text" | "img"
+    logText: string
+    logImg: string
+}
+
+export function LogItem({ leadElement, logText, logImg }: LogItemProps) {
+    const textElement = <div className={classes.textDiv}>{logText}</div>
+    const imgElement = <div className={classes.imgDiv}><img src={logImg} className={classes.img} /></div>
+
+    return (
+        <Group style={{ display: "flex" }}>
+            {leadElement === "text" ? (
+                <>
+                    {textElement}
+                    {imgElement}
+                </>
+            ) : (
+                <>
+                    {imgElement}
+                    {textElement}
+                </>
+            )}
+        </Group>
+    );
+}
+
+interface LogEntryData {
+    text: string;
+    img: string;
+}
+
+interface LogProps {
+    logEntries: LogEntryData[];
+}
+
+export default function ProjectLog({ logEntries }: LogProps) {
+    return logEntries.map((item, index) => (
+        <LogItem
+            key={index}
+            leadElement={(index % 2 !== 0) ? "text" : "img"}
+            logText={item.text}
+            logImg={item.img}
+        />
+    ));
+}

--- a/src/components/ProjectLogItem.module.css
+++ b/src/components/ProjectLogItem.module.css
@@ -1,0 +1,13 @@
+.textDiv {
+    display: "flex";
+    flex: 1;
+}
+
+.imgDiv {
+    aspect-ratio: "1/1";
+    width: 30%;
+}
+
+.img {
+    border-radius: var(--mantine-radius-md);
+}

--- a/src/resources/content.tsx
+++ b/src/resources/content.tsx
@@ -1,0 +1,28 @@
+const gs750Items = [
+    {
+        text: "lorem ipsum dolor sit amet",
+        img: "https://static.annejulian.net/static/img/gs750/skateboard.webp"
+    },
+    {
+        text: "adjhkdfguhijkewrlkjsdfsdf",
+        img: "https://static.annejulian.net/static/img/gs750/fiberglass.webp"
+    },
+    {
+        text: "Ashgrgrdgfdfgfdg",
+        img: "https://static.annejulian.net/static/img/gs750/seat.webp"
+    },
+    {
+        text: "asdadasda",
+        img: "https://static.annejulian.net/static/img/gs750/gs750_spacer_fusebox.webp"
+    }
+];
+
+const projectTiles = [
+    { link: '/rabbit', tileImg: "https://static.annejulian.net/static/img/rabbit/rabbit.png", tileText: "lorem ipsum dolor sit amet", key: 'rabbit' },
+    { link: '/miniped', tileImg: "https://static.annejulian.net/static/img/miniped/mastminiped.jpg", tileText: "lorem ipsum dolor sit amet", key: 'miniped' },
+    { link: '/dive', tileImg: "https://static.annejulian.net/static/img/dive/mastdive.jpg", tileText: "lorem ipsum dolor sit amet", key: 'dive' },
+    { link: '/drone', tileImg: "https://static.annejulian.net/static/img/drone/drone_hero.png", tileText: "lorem ipsum dolor sit amet", key: 'drone' },
+    { link: '/gs750', tileImg: "https://static.annejulian.net/static/img/gs750/gs750_hero.png", tileText: "lorem ipsum dolor sit amet", key: 'gs750' }
+];
+
+export { projectTiles, gs750Items }; 


### PR DESCRIPTION
This PR adds components for the individual project logs and moves the content for those logs to a common content file.

- Adds a common content file for storing website content in one place
- Add ProjectLog and LogItems components for rendering an object from the content file as a blog page