### PR TITLE
Remove erroneous import statement

### DIFF
--- a/src/resources/content.tsx
+++ b/src/resources/content.tsx
@@ -1,5 +1,3 @@
-import { url } from "inspector";
-
 const urlPrefix = "https://d2l2tjqqxralki.cloudfront.net/img/";
 
 export interface ProjectLogItem {


### PR DESCRIPTION
Tab-to-autocomplete inserted a stray import statement that broke deployment.  This PR removes it.