### PR TITLE
Close menu drawer on link click

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -16,7 +16,7 @@ const links = [
 ];
 
 export default function HeaderSimple() {
-    const [opened, { toggle }] = useDisclosure(false);
+    const [opened, { close, toggle }] = useDisclosure(false);
     const [active, setActive] = useState(links[0].link);
 
     const items = links.map((link) => (
@@ -42,6 +42,7 @@ export default function HeaderSimple() {
             data-active={active === link.link || undefined}
             onClick={() => {
                 setActive(link.link);
+                close();
             }}
         >
             {link.icon}
@@ -71,7 +72,7 @@ export default function HeaderSimple() {
                 <Drawer hiddenFrom="xs" position='right' size="40%" opened={opened} onClose={toggle} radius="md" overlayProps={{ backgroundOpacity: 0.5, blur: 4 }}>
                     <Stack gap={5} align='flex-start'>
                         {drawerItems}
-                        <ThemeToggle className={classes.link}>Theme</ThemeToggle>
+                        <ThemeToggle onClose={close} className={classes.link}>Theme</ThemeToggle>
                     </Stack>
                 </Drawer>
             </Container>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -7,9 +7,10 @@ import Link from 'next/link'
 interface ThemeToggleProps {
     children?: React.ReactNode;
     className?: string;
+    onClose?: () => void;
 }
 
-export function ThemeToggle({ children, className }: ThemeToggleProps) {
+export function ThemeToggle({ children, className, onClose }: ThemeToggleProps) {
     const { setColorScheme } = useMantineColorScheme();
 
     const computedColorScheme = useComputedColorScheme('light', { getInitialValueInEffect: true });
@@ -18,6 +19,7 @@ export function ThemeToggle({ children, className }: ThemeToggleProps) {
         <Link
             onClick={() => {
                 setColorScheme(computedColorScheme === 'light' ? 'dark' : 'light');
+                onClose?.();
             }}
             href={""}
             aria-label="Toggle color scheme"


### PR DESCRIPTION
This PR adds the close() function to onClick hooks for the links in the menu drawer, so that it closes upon link selection.